### PR TITLE
Add icon-driven UI polish across core pages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,8 +11,8 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.577.0",
-        "next": "^16.2.0",
+        "lucide-react": "^1.7.0",
+        "next": "^16.2.1",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
@@ -27,11 +27,11 @@
         "@types/react-dom": "^19.2.3",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "9.39.4",
-        "eslint-config-next": "^16.2.0",
+        "eslint-config-next": "^16.2.1",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.1.0",
+        "vitest": "^4.1.1",
       },
     },
   },
@@ -175,25 +175,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.2.0", "", {}, "sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA=="],
+    "@next/env": ["@next/env@16.2.1", "", {}, "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg=="],
 
-    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.0", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-3D3pEMcGKfENC9Pzlkr67GOm+205+5hRdYPZvHuNIy5sr9k0ybSU8g+sxOO/R/RLEh/gWZ3UlY+5LmEyZ1xgXQ=="],
+    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.1", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/JZsqKzKt01IFoiLLAzlNqys7qk2F3JkcUhj50zuRhKDQkZNOz9E5N6wAQWprXdsvjRP4lTFj+/+36NSv5AwhQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-/hV8erWq4SNlVgglUiW5UmQ5Hwy5EW/AbbXlJCn6zkfKxTy/E/U3V8U1Ocm2YCTUoFgQdoMxRyRMOW5jYy4ygg=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-GkjL/Q7MWOwqWR9zoxu1TIHzkOI2l2BHCf7FzeQG87zPgs+6WDh+oC9Sw9ARuuL/FUk6JNCgKRkA6rEQYadUaw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-DRrNJKW+/eimrZgdhVN1uvkN1OI4j6Lpefwr44jKQ0YQzztlmOBUUzHuV5GxOMPK3nmodAYElUVCY8ZXo/IWeA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -469,19 +469,19 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.0", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "chai": "^6.2.2", "tinyrainbow": "^3.0.3" } }, "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA=="],
+    "@vitest/expect": ["@vitest/expect@4.1.1", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.1", "@vitest/utils": "4.1.1", "chai": "^6.2.2", "tinyrainbow": "^3.0.3" } }, "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.0", "", { "dependencies": { "@vitest/spy": "4.1.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.1", "", { "dependencies": { "@vitest/spy": "4.1.1", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.0", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.1", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.0", "", { "dependencies": { "@vitest/utils": "4.1.0", "pathe": "^2.0.3" } }, "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.1", "", { "dependencies": { "@vitest/utils": "4.1.1", "pathe": "^2.0.3" } }, "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "@vitest/utils": "4.1.0", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "@vitest/utils": "4.1.1", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.0", "", {}, "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw=="],
+    "@vitest/spy": ["@vitest/spy@4.1.1", "", {}, "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
+    "@vitest/utils": ["@vitest/utils@4.1.1", "", { "dependencies": { "@vitest/pretty-format": "4.1.1", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -623,7 +623,7 @@
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "eslint-config-next": ["eslint-config-next@16.2.0", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.0", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-LlVJrWnjIkgQRECjIOELyAtrWFqzn326ARS5ap7swc1YKL4wkry6/gszn6wi5ZDWKxKe7fanxArvhqMoAzbL7w=="],
+    "eslint-config-next": ["eslint-config-next@16.2.1", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.1", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg=="],
 
     "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
 
@@ -855,7 +855,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
+    "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -877,7 +877,7 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "next": ["next@16.2.0", "", { "dependencies": { "@next/env": "16.2.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.0", "@next/swc-darwin-x64": "16.2.0", "@next/swc-linux-arm64-gnu": "16.2.0", "@next/swc-linux-arm64-musl": "16.2.0", "@next/swc-linux-x64-gnu": "16.2.0", "@next/swc-linux-x64-musl": "16.2.0", "@next/swc-win32-arm64-msvc": "16.2.0", "@next/swc-win32-x64-msvc": "16.2.0", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NLBVrJy1pbV1Yn00L5sU4vFyAHt5XuSjzrNyFnxo6Com0M0KrL6hHM5B99dbqXb2bE9pm4Ow3Zl1xp6HVY9edQ=="],
+    "next": ["next@16.2.1", "", { "dependencies": { "@next/env": "16.2.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.1", "@next/swc-darwin-x64": "16.2.1", "@next/swc-linux-arm64-gnu": "16.2.1", "@next/swc-linux-arm64-musl": "16.2.1", "@next/swc-linux-x64-gnu": "16.2.1", "@next/swc-linux-x64-musl": "16.2.1", "@next/swc-win32-arm64-msvc": "16.2.1", "@next/swc-win32-x64-msvc": "16.2.1", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -1085,7 +1085,7 @@
 
     "vite": ["vite@8.0.1", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.10", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw=="],
 
-    "vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
+    "vitest": ["vitest@4.1.1", "", { "dependencies": { "@vitest/expect": "4.1.1", "@vitest/mocker": "4.1.1", "@vitest/pretty-format": "4.1.1", "@vitest/runner": "4.1.1", "@vitest/snapshot": "4.1.1", "@vitest/spy": "4.1.1", "@vitest/utils": "4.1.1", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.1", "@vitest/browser-preview": "4.1.1", "@vitest/browser-webdriverio": "4.1.1", "@vitest/ui": "4.1.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.577.0",
-    "next": "^16.2.0",
+    "lucide-react": "^1.7.0",
+    "next": "^16.2.1",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
@@ -33,11 +33,11 @@
     "@types/react-dom": "^19.2.3",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "9.39.4",
-    "eslint-config-next": "^16.2.0",
+    "eslint-config-next": "^16.2.1",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.1"
   },
   "trustedDependencies": [
     "unrs-resolver"

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -2,6 +2,17 @@
 
 import Link from "next/link";
 import {
+  ArrowLeft,
+  BarChart3,
+  Database,
+  Laptop,
+  MapPinned,
+  MonitorCog,
+  SlidersHorizontal,
+  Trash2,
+  Wifi,
+} from "lucide-react";
+import {
   useEffect,
   useState,
   useSyncExternalStore,
@@ -85,11 +96,13 @@ function SectionCard({
   title,
   description,
   children,
+  icon: Icon,
 }: {
   eyebrow: string;
   title: string;
   description?: string;
   children: ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
 }) {
   return (
     <section className="rounded-[28px] border border-white/10 bg-gray-950/55 p-5 shadow-[0_24px_80px_-48px_rgba(251,191,36,0.45)] backdrop-blur-md md:p-7">
@@ -97,9 +110,14 @@ function SectionCard({
         <div className="text-[11px] uppercase tracking-[0.28em] text-yellow-300/70">
           {eyebrow}
         </div>
-        <h2 className="mt-2 text-2xl font-semibold text-white md:text-3xl">
-          {title}
-        </h2>
+        <div className="mt-2 flex items-center gap-3">
+          <div className="rounded-full border border-white/10 bg-white/5 p-2 text-yellow-300">
+            <Icon className="size-5" />
+          </div>
+          <h2 className="text-2xl font-semibold text-white md:text-3xl">
+            {title}
+          </h2>
+        </div>
         {description ? (
           <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-400">
             {description}
@@ -261,6 +279,7 @@ export default function Debug() {
               href="/?debug=true"
               className="inline-flex items-center justify-center rounded-full border border-white/12 bg-white/6 px-5 py-3 text-center text-sm font-medium text-white whitespace-nowrap transition-colors hover:border-yellow-300/35 hover:bg-yellow-300/10 hover:text-yellow-100"
             >
+              <ArrowLeft className="mr-2 size-4" />
               Back to Wattlyzer
             </Link>
           </div>
@@ -271,6 +290,7 @@ export default function Debug() {
             eyebrow="Runtime"
             title="Build and environment"
             description="Basic versioning and runtime context for the current browser session."
+            icon={MonitorCog}
           >
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
               <InfoTile label="Version" value={packageJson.version} />
@@ -284,6 +304,7 @@ export default function Debug() {
             eyebrow="Configuration"
             title="Current settings"
             description="The exact values used by the solar and scheduling logic."
+            icon={SlidersHorizontal}
           >
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
               <InfoTile
@@ -333,6 +354,7 @@ export default function Debug() {
             eyebrow="Location"
             title="Geolocation and cache keys"
             description="Coordinates used for the solar estimate and the derived cache key."
+            icon={MapPinned}
           >
             {position ? (
               <div className="space-y-4">
@@ -380,6 +402,7 @@ export default function Debug() {
               eyebrow="Cache"
               title="Cache status"
               description="Whether solar and market API responses are currently available in local storage."
+              icon={Database}
             >
               {cacheInfo ? (
                 <div className="grid gap-4">
@@ -410,6 +433,7 @@ export default function Debug() {
                         onClick={() => handleClearCache(SOLAR_CACHE_KEY)}
                         className="inline-flex items-center justify-center rounded-full border border-white/12 bg-white/6 px-4 py-2 text-sm font-medium text-white transition-colors hover:border-yellow-300/35 hover:bg-yellow-300/10 hover:text-yellow-100"
                       >
+                        <Trash2 className="mr-2 size-4" />
                         Clear solar cache
                       </button>
                     </div>
@@ -442,6 +466,7 @@ export default function Debug() {
                         onClick={() => handleClearCache(MARKET_CACHE_KEY)}
                         className="inline-flex items-center justify-center rounded-full border border-white/12 bg-white/6 px-4 py-2 text-sm font-medium text-white transition-colors hover:border-yellow-300/35 hover:bg-yellow-300/10 hover:text-yellow-100"
                       >
+                        <Trash2 className="mr-2 size-4" />
                         Clear market cache
                       </button>
                     </div>
@@ -458,6 +483,7 @@ export default function Debug() {
               eyebrow="API"
               title="Loaded data"
               description="Whether the current solar and market requests have resolved and if any API error was captured."
+              icon={Wifi}
             >
               <div className="grid gap-4 sm:grid-cols-2">
                 <InfoTile
@@ -613,6 +639,7 @@ export default function Debug() {
             eyebrow="Ranking"
             title="Top scheduling slots"
             description="The best solar-heavy windows, the cheapest windows, and the final recommendation for the current debug run."
+            icon={BarChart3}
           >
             {topSlotsResult ? (
               <div className="grid gap-6 xl:grid-cols-2">
@@ -712,6 +739,7 @@ export default function Debug() {
             eyebrow="Client"
             title="Browser information"
             description="Useful runtime details when debugging layout, storage, or browser-specific behavior."
+            icon={Laptop}
           >
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <InfoTile label="Screen Size" value={systemInfo.screenSize} />

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { ArrowLeft, Building2, Mail, Phone, Scale } from "lucide-react";
 import type { ReactNode } from "react";
 import { FooterLinks } from "@/components/footer-links";
 
@@ -11,13 +12,18 @@ export const metadata: Metadata = {
 function InfoCard({
   title,
   children,
+  icon: Icon,
 }: {
   title: string;
   children: ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
 }) {
   return (
     <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
-      <h2 className="text-xl font-semibold text-white">{title}</h2>
+      <h2 className="flex items-center gap-2 text-xl font-semibold text-white">
+        <Icon className="size-5 text-yellow-300" />
+        {title}
+      </h2>
       <div className="mt-3 text-sm leading-7 text-gray-300">{children}</div>
     </section>
   );
@@ -52,6 +58,7 @@ export default function Legal() {
               href="/"
               className="inline-flex items-center justify-center rounded-full border border-white/12 bg-white/6 px-5 py-3 text-center text-sm font-medium text-white whitespace-nowrap transition-colors hover:border-yellow-300/35 hover:bg-yellow-300/10 hover:text-yellow-100"
             >
+              <ArrowLeft className="mr-2 size-4" />
               Back to Wattlyzer
             </Link>
           </div>
@@ -63,13 +70,18 @@ export default function Legal() {
               <div className="text-[11px] uppercase tracking-[0.28em] text-yellow-300/70">
                 Required Information
               </div>
-              <h2 className="mt-2 text-2xl font-semibold text-white md:text-3xl">
-                Information according to § 5 TMG
-              </h2>
+              <div className="mt-2 flex items-center gap-3">
+                <div className="rounded-full border border-white/10 bg-white/5 p-2 text-yellow-300">
+                  <Scale className="size-5" />
+                </div>
+                <h2 className="text-2xl font-semibold text-white md:text-3xl">
+                  Information according to § 5 TMG
+                </h2>
+              </div>
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
-              <InfoCard title="Operator">
+              <InfoCard title="Operator" icon={Building2}>
                 Leon Bojanowski
                 <br />
                 Marienstraße 3b
@@ -79,9 +91,10 @@ export default function Legal() {
                 Germany
               </InfoCard>
 
-              <InfoCard title="Contact">
+              <InfoCard title="Contact" icon={Mail}>
                 E-Mail: leongaborbojanowski04@gmail.com
                 <br />
+                <Phone className="mr-2 inline size-4 text-yellow-300" />
                 Phone: +49 160 3020390
               </InfoCard>
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -464,8 +464,8 @@ function SchedulingPanel() {
                   </div>
 
                   <div className="mt-5 grid gap-3 sm:grid-cols-2">
-                    <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4">
-                      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
+                    <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4 text-center">
+                      <div className="flex items-center justify-center gap-2 text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
                         <Sun className="size-4" />
                         Average Solar
                       </div>
@@ -473,8 +473,8 @@ function SchedulingPanel() {
                         {(schedulingResult.avgSolarProduction || 0).toFixed(0)} Wh
                       </div>
                     </div>
-                    <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4">
-                      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
+                    <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4 text-center">
+                      <div className="flex items-center justify-center gap-2 text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
                         <BadgeEuro className="size-4" />
                         Average Price
                       </div>
@@ -615,17 +615,29 @@ function SchedulingPanel() {
                       className="mt-4"
                     >
                       <TabsList className="grid h-auto w-full grid-cols-3 gap-1 bg-white/10 p-1">
-                        <TabsTrigger value="combined">
-                          <Scale className="size-4" />
-                          Combined
+                        <TabsTrigger
+                          value="combined"
+                          className="gap-1 px-1.5 text-[11px] sm:gap-1.5 sm:px-3 sm:text-sm"
+                        >
+                          <Scale className="size-3.5 sm:size-4" />
+                          <span className="sm:hidden">Both</span>
+                          <span className="hidden sm:inline">Combined</span>
                         </TabsTrigger>
-                        <TabsTrigger value="solar-only">
-                          <Sun className="size-4" />
-                          Solar only
+                        <TabsTrigger
+                          value="solar-only"
+                          className="gap-1 px-1.5 text-[11px] sm:gap-1.5 sm:px-3 sm:text-sm"
+                        >
+                          <Sun className="size-3.5 sm:size-4" />
+                          <span className="sm:hidden">Solar</span>
+                          <span className="hidden sm:inline">Solar only</span>
                         </TabsTrigger>
-                        <TabsTrigger value="price-only">
-                          <BadgeEuro className="size-4" />
-                          Price only
+                        <TabsTrigger
+                          value="price-only"
+                          className="gap-1 px-1.5 text-[11px] sm:gap-1.5 sm:px-3 sm:text-sm"
+                        >
+                          <BadgeEuro className="size-3.5 sm:size-4" />
+                          <span className="sm:hidden">Price</span>
+                          <span className="hidden sm:inline">Price only</span>
                         </TabsTrigger>
                       </TabsList>
                     </Tabs>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import {
   ChevronDown,
   CircleAlert,
   LoaderCircle,
-  PanelsTopLeft,
   Scale,
   Sun,
   SunMedium,
@@ -667,10 +666,6 @@ export default function Home() {
         <header className="rounded-[32px] border border-white/12 bg-black/30 p-6 shadow-[0_28px_100px_-56px_rgba(251,191,36,0.6)] backdrop-blur-md md:p-8">
           <div className="flex flex-col items-center text-center">
             <div>
-              <div className="inline-flex items-center gap-2 rounded-full border border-yellow-300/20 bg-yellow-300/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-yellow-200">
-                <PanelsTopLeft className="size-4" />
-                Solar-aware scheduling
-              </div>
               <h1 className="text-4xl font-bold text-white md:text-6xl">
                 <span className="sr-only">
                   wattlyzer - smart appliance scheduling

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,17 @@
 "use client";
 
 import {
+  BadgeEuro,
+  ChevronDown,
+  CircleAlert,
+  LoaderCircle,
+  PanelsTopLeft,
+  Scale,
+  Sun,
+  SunMedium,
+  TriangleAlert,
+} from "lucide-react";
+import {
   useEffect,
   useRef,
   useState,
@@ -145,11 +156,27 @@ function StatusPanel({
     yellow:
       "border-yellow-300/35 bg-yellow-400/15 text-yellow-50 shadow-[0_0_0_1px_rgba(253,224,71,0.12)]",
   };
+  const icons = {
+    red: CircleAlert,
+    orange: TriangleAlert,
+    gray: LoaderCircle,
+    yellow: SunMedium,
+  };
+  const Icon = icons[accent];
 
   return (
     <div className={`rounded-2xl border p-5 ${tones[accent]}`}>
-      <div className="text-lg font-semibold">{title}</div>
-      <p className="mt-2 text-sm leading-6 text-gray-300">{body}</p>
+      <div className="flex items-start gap-3">
+        <Icon
+          className={`mt-0.5 size-5 shrink-0 ${
+            accent === "gray" ? "animate-spin" : ""
+          }`}
+        />
+        <div>
+          <div className="text-lg font-semibold">{title}</div>
+          <p className="mt-2 text-sm leading-6 text-gray-300">{body}</p>
+        </div>
+      </div>
     </div>
   );
 }
@@ -438,7 +465,8 @@ function SchedulingPanel() {
 
                   <div className="mt-5 grid gap-3 sm:grid-cols-2">
                     <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4">
-                      <div className="text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
+                      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
+                        <Sun className="size-4" />
                         Average Solar
                       </div>
                       <div className="mt-2 text-2xl font-semibold text-white">
@@ -446,7 +474,8 @@ function SchedulingPanel() {
                       </div>
                     </div>
                     <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4">
-                      <div className="text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
+                      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-yellow-200/70">
+                        <BadgeEuro className="size-4" />
                         Average Price
                       </div>
                       <div className="mt-2 text-2xl font-semibold text-white">
@@ -465,7 +494,10 @@ function SchedulingPanel() {
 
               {apiError && (
                 <div className="rounded-2xl border border-red-400/20 bg-red-500/10 px-4 py-3 text-sm text-red-200">
-                  API Error: {apiError}
+                  <div className="flex items-start gap-2">
+                    <CircleAlert className="mt-0.5 size-4 shrink-0" />
+                    <span>API Error: {apiError}</span>
+                  </div>
                 </div>
               )}
             </div>
@@ -491,7 +523,7 @@ function SchedulingPanel() {
                   showAdvancedOptions ? "rotate-180" : ""
                 }`}
               >
-                ▼
+                <ChevronDown className="size-5" />
               </span>
             </button>
 
@@ -583,9 +615,18 @@ function SchedulingPanel() {
                       className="mt-4"
                     >
                       <TabsList className="grid h-auto w-full grid-cols-3 gap-1 bg-white/10 p-1">
-                        <TabsTrigger value="combined">Combined</TabsTrigger>
-                        <TabsTrigger value="solar-only">Solar only</TabsTrigger>
-                        <TabsTrigger value="price-only">Price only</TabsTrigger>
+                        <TabsTrigger value="combined">
+                          <Scale className="size-4" />
+                          Combined
+                        </TabsTrigger>
+                        <TabsTrigger value="solar-only">
+                          <Sun className="size-4" />
+                          Solar only
+                        </TabsTrigger>
+                        <TabsTrigger value="price-only">
+                          <BadgeEuro className="size-4" />
+                          Price only
+                        </TabsTrigger>
                       </TabsList>
                     </Tabs>
                   </div>
@@ -614,6 +655,10 @@ export default function Home() {
         <header className="rounded-[32px] border border-white/12 bg-black/30 p-6 shadow-[0_28px_100px_-56px_rgba(251,191,36,0.6)] backdrop-blur-md md:p-8">
           <div className="flex flex-col items-center text-center">
             <div>
+              <div className="inline-flex items-center gap-2 rounded-full border border-yellow-300/20 bg-yellow-300/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-yellow-200">
+                <PanelsTopLeft className="size-4" />
+                Solar-aware scheduling
+              </div>
               <h1 className="text-4xl font-bold text-white md:text-6xl">
                 <span className="sr-only">
                   wattlyzer - smart appliance scheduling

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,12 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import {
+  ArrowLeft,
+  Clock3,
+  HardDrive,
+  MapPin,
+  ShieldCheck,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { FooterLinks } from "@/components/footer-links";
 
@@ -11,13 +18,18 @@ export const metadata: Metadata = {
 function PrivacyCard({
   title,
   children,
+  icon: Icon,
 }: {
   title: string;
   children: ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
 }) {
   return (
     <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
-      <h2 className="text-xl font-semibold text-white">{title}</h2>
+      <h2 className="flex items-center gap-2 text-xl font-semibold text-white">
+        <Icon className="size-5 text-yellow-300" />
+        {title}
+      </h2>
       <div className="mt-3 text-sm leading-7 text-gray-300">{children}</div>
     </section>
   );
@@ -52,6 +64,7 @@ export default function Privacy() {
               href="/"
               className="inline-flex items-center justify-center rounded-full border border-white/12 bg-white/6 px-5 py-3 text-center text-sm font-medium text-white whitespace-nowrap transition-colors hover:border-yellow-300/35 hover:bg-yellow-300/10 hover:text-yellow-100"
             >
+              <ArrowLeft className="mr-2 size-4" />
               Back to Wattlyzer
             </Link>
           </div>
@@ -62,9 +75,14 @@ export default function Privacy() {
             <div className="text-[11px] uppercase tracking-[0.28em] text-yellow-300/70">
               Privacy Overview
             </div>
-            <h2 className="mt-2 text-2xl font-semibold text-white md:text-3xl">
-              Local-first data handling
-            </h2>
+            <div className="mt-2 flex items-center gap-3">
+              <div className="rounded-full border border-white/10 bg-white/5 p-2 text-yellow-300">
+                <ShieldCheck className="size-5" />
+              </div>
+              <h2 className="text-2xl font-semibold text-white md:text-3xl">
+                Local-first data handling
+              </h2>
+            </div>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-400">
               The app only requests what it needs for solar and price
               estimation, and most persistence stays in the browser.
@@ -72,24 +90,24 @@ export default function Privacy() {
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
-            <PrivacyCard title="Location data usage">
+            <PrivacyCard title="Location data usage" icon={MapPin}>
               Your location is used only to provide solar energy estimates for
               your area. This information is sent to the solar estimation API
               so the forecast can reflect local conditions.
             </PrivacyCard>
 
-            <PrivacyCard title="Local storage">
+            <PrivacyCard title="Local storage" icon={HardDrive}>
               Your settings and cached API responses are stored locally in the
               browser to improve performance and reduce unnecessary API calls.
             </PrivacyCard>
 
-            <PrivacyCard title="Data sharing">
+            <PrivacyCard title="Data sharing" icon={ShieldCheck}>
               We do not sell or distribute your personal data. External
               communication is limited to the solar and market APIs required to
               generate recommendations.
             </PrivacyCard>
 
-            <PrivacyCard title="Retention">
+            <PrivacyCard title="Retention" icon={Clock3}>
               Cached data remains on your device and can be cleared manually.
               No personal data is retained on Wattlyzer servers.
             </PrivacyCard>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,19 @@
 "use client";
 
 import Link from "next/link";
+import {
+  ArrowLeft,
+  BatteryCharging,
+  CloudSun,
+  Compass,
+  PanelsTopLeft,
+  Ruler,
+  Sun,
+  Sunrise,
+  Sunset,
+  Trash2,
+  Zap,
+} from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { FooterLinks } from "@/components/footer-links";
 import { Slider } from "@/components/ui/slider";
@@ -38,13 +51,16 @@ function getDirectionLabel(azimut: number) {
 function SummaryItem({
   label,
   value,
+  icon: Icon,
 }: {
   label: string;
   value: string;
+  icon: React.ComponentType<{ className?: string }>;
 }) {
   return (
     <div className="rounded-2xl border border-white/10 bg-black/25 px-4 py-4 backdrop-blur-sm">
-      <div className="text-[11px] uppercase tracking-[0.24em] text-yellow-200/70">
+      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.24em] text-yellow-200/70">
+        <Icon className="size-4" />
         {label}
       </div>
       <div className="mt-2 text-lg font-semibold text-white">{value}</div>
@@ -57,11 +73,13 @@ function SectionCard({
   title,
   description,
   children,
+  icon: Icon,
 }: {
   eyebrow: string;
   title: string;
   description: string;
   children: ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
 }) {
   return (
     <section className="rounded-[28px] border border-white/10 bg-gray-950/55 p-5 shadow-[0_24px_80px_-48px_rgba(251,191,36,0.45)] backdrop-blur-md md:p-7">
@@ -69,9 +87,14 @@ function SectionCard({
         <div className="text-[11px] uppercase tracking-[0.28em] text-yellow-300/70">
           {eyebrow}
         </div>
-        <h2 className="mt-2 text-2xl font-semibold text-white md:text-3xl">
-          {title}
-        </h2>
+        <div className="mt-2 flex items-center gap-3">
+          <div className="rounded-full border border-white/10 bg-white/5 p-2 text-yellow-300">
+            <Icon className="size-5" />
+          </div>
+          <h2 className="text-2xl font-semibold text-white md:text-3xl">
+            {title}
+          </h2>
+        </div>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-400">
           {description}
         </p>
@@ -86,6 +109,7 @@ function SliderSetting({
   label,
   valueLabel,
   description,
+  icon: Icon,
   value,
   min,
   max,
@@ -97,6 +121,7 @@ function SliderSetting({
   label: string;
   valueLabel: string;
   description: ReactNode;
+  icon: React.ComponentType<{ className?: string }>;
   value: number;
   min: number;
   max: number;
@@ -109,8 +134,9 @@ function SliderSetting({
       <div>
         <label
           htmlFor={id}
-          className="block text-lg font-semibold text-white md:text-xl"
+          className="flex items-center gap-2 text-lg font-semibold text-white md:text-xl"
         >
+          <Icon className="size-5 text-yellow-300" />
           {label}
         </label>
         <div className="mt-2 text-sm leading-6 text-gray-400">{description}</div>
@@ -143,6 +169,7 @@ function ToggleSetting({
   checked,
   onCheckedChange,
   accent,
+  icon: Icon,
 }: {
   id: string;
   title: string;
@@ -150,6 +177,7 @@ function ToggleSetting({
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
   accent: string;
+  icon: React.ComponentType<{ className?: string }>;
 }) {
   return (
     <div className="rounded-2xl border border-white/8 bg-white/[0.04] p-4">
@@ -157,8 +185,9 @@ function ToggleSetting({
         <div className="max-w-xl">
           <label
             htmlFor={id}
-            className="block text-lg font-semibold text-white md:text-xl"
+            className="flex items-center gap-2 text-lg font-semibold text-white md:text-xl"
           >
+            <Icon className="size-5 text-yellow-300" />
             {title}
           </label>
           <p className="mt-2 text-sm leading-6 text-gray-400">{description}</p>
@@ -221,6 +250,7 @@ export default function Settings() {
               href="/"
               className="inline-flex items-center justify-center rounded-full border border-white/12 bg-white/6 px-5 py-3 text-center text-sm font-medium text-white whitespace-nowrap transition-colors hover:border-yellow-300/35 hover:bg-yellow-300/10 hover:text-yellow-100"
             >
+              <ArrowLeft className="mr-2 size-4" />
               Back to Wattlyzer
             </Link>
           </div>
@@ -229,9 +259,14 @@ export default function Settings() {
             <SummaryItem
               label="Direction"
               value={`${directionLabel} (${settings.azimut}°)`}
+              icon={Compass}
             />
-            <SummaryItem label="Tilt" value={`${settings.angle}°`} />
-            <SummaryItem label="System Size" value={`${settings.kwh} kW`} />
+            <SummaryItem label="Tilt" value={`${settings.angle}°`} icon={Ruler} />
+            <SummaryItem
+              label="System Size"
+              value={`${settings.kwh} kW`}
+              icon={Zap}
+            />
             <SummaryItem
               label="Shading"
               value={
@@ -243,6 +278,7 @@ export default function Settings() {
                     }${settings.eveningShading ? "PM" : ""} active`
                   : "None"
               }
+              icon={CloudSun}
             />
           </div>
         </header>
@@ -252,11 +288,13 @@ export default function Settings() {
             eyebrow="Panel Setup"
             title="Core panel geometry"
             description="These values drive the solar forecast request directly. Keep them aligned with the physical panel installation rather than with short-term weather or electricity prices."
+            icon={PanelsTopLeft}
           >
             <SliderSetting
               id="azimut-slider"
               label="Azimut"
               valueLabel={`${settings.azimut}°`}
+              icon={Compass}
               description={
                 <>
                   Compass direction your panels face.
@@ -284,6 +322,7 @@ export default function Settings() {
               id="angle-slider"
               label="Tilt Angle"
               valueLabel={`${settings.angle}°`}
+              icon={Ruler}
               description="Panel angle from horizontal. Flat roofs sit near 0°, wall-mounted or steep roofs move higher."
               value={settings.angle}
               min={0}
@@ -304,6 +343,7 @@ export default function Settings() {
               id="kwh-slider"
               label="System Size"
               valueLabel={`${settings.kwh} kW`}
+              icon={BatteryCharging}
               description="Total peak capacity of the installed solar system."
               value={settings.kwh}
               min={1}
@@ -325,6 +365,7 @@ export default function Settings() {
             eyebrow="Shading Profile"
             title="Morning and evening losses"
             description="Use shading only when the forecast is consistently too optimistic because sunlight is blocked at the same time every day. The current model applies a fixed 50% reduction within the shaded window."
+            icon={CloudSun}
           >
             <ToggleSetting
               id="morning-shading-switch"
@@ -335,6 +376,7 @@ export default function Settings() {
                 updateSettings({ morningShading: checked })
               }
               accent="text-amber-200"
+              icon={Sunrise}
             />
 
             {settings.morningShading && (
@@ -343,6 +385,7 @@ export default function Settings() {
                   id="shading-end-time-slider"
                   label="Morning shading clears"
                   valueLabel={`${settings.shadingEndTime}:00`}
+                  icon={Sun}
                   description="Solar output is reduced before this hour."
                   value={settings.shadingEndTime}
                   min={6}
@@ -371,6 +414,7 @@ export default function Settings() {
                 updateSettings({ eveningShading: checked })
               }
               accent="text-orange-200"
+              icon={Sunset}
             />
 
             {settings.eveningShading && (
@@ -379,6 +423,7 @@ export default function Settings() {
                   id="shading-start-time-slider"
                   label="Evening shading begins"
                   valueLabel={`${settings.shadingStartTime}:00`}
+                  icon={Sun}
                   description="Solar output is reduced from this hour onward."
                   value={settings.shadingStartTime}
                   min={12}
@@ -403,6 +448,7 @@ export default function Settings() {
             eyebrow="Maintenance"
             title="Cache and recovery"
             description="Cached API results make the app faster. Clear them only when the forecast or price data looks stale or inconsistent."
+            icon={Trash2}
           >
             <div className="grid gap-5 rounded-2xl border border-red-400/15 bg-red-500/5 p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
               <div>
@@ -423,6 +469,7 @@ export default function Settings() {
                 className="inline-flex items-center justify-center rounded-full bg-red-600 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
                 disabled={cacheCleared}
               >
+                <Trash2 className="mr-2 size-4" />
                 {cacheCleared ? "Cache Cleared" : "Clear Cache"}
               </button>
             </div>

--- a/src/components/footer-links.tsx
+++ b/src/components/footer-links.tsx
@@ -1,6 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import {
+  Bug,
+  ExternalLink,
+  Scale,
+  Settings as SettingsIcon,
+  Shield,
+} from "lucide-react";
 import { useSyncExternalStore } from "react";
 import { isDebugMode } from "@/lib/utils";
 
@@ -35,33 +42,38 @@ export function FooterLinks() {
           target="_blank"
           rel="noopener noreferrer"
           prefetch={false}
-          className="shrink-0 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
         >
+          <ExternalLink className="size-3.5" />
           GitHub
         </Link>
         <Link
           href="/legal"
-          className="shrink-0 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
         >
+          <Scale className="size-3.5" />
           Legal
         </Link>
         <Link
           href="/privacy"
-          className="shrink-0 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
         >
+          <Shield className="size-3.5" />
           Privacy
         </Link>
         <Link
           href="/settings"
-          className="shrink-0 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
         >
+          <SettingsIcon className="size-3.5" />
           Settings
         </Link>
         {showDebugLink && (
           <Link
             href="/debug"
-            className="shrink-0 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-1.5 text-xs text-gray-300 whitespace-nowrap transition-colors hover:bg-white/8 hover:text-white sm:px-3 sm:py-2 sm:text-sm"
           >
+            <Bug className="size-3.5" />
             Debug
           </Link>
         )}

--- a/src/components/footer-links.tsx
+++ b/src/components/footer-links.tsx
@@ -36,7 +36,7 @@ export function FooterLinks() {
 
   return (
     <div className="mt-10 pb-safe-bottom">
-      <div className="flex flex-nowrap items-center justify-center gap-1 overflow-x-auto rounded-full border border-white/10 bg-black/25 px-2 py-1.5 backdrop-blur-sm">
+      <div className="flex flex-wrap items-center justify-center gap-1 rounded-[28px] border border-white/10 bg-black/25 px-2 py-1.5 backdrop-blur-sm sm:rounded-full">
         <Link
           href="https://github.com/F1nal04/wattlyzer"
           target="_blank"


### PR DESCRIPTION
## Summary
- Added lucide icons and refreshed spacing/alignment across the home, settings, debug, legal, and privacy pages.
- Improved the scheduling experience with icon-backed status panels, tab labels, and clearer summary cards.
- Updated footer links and legal/privacy sections with more structured, accessible layouts.
- Bumped `next`, `eslint-config-next`, `lucide-react`, and `vitest` to newer versions.

## Testing
- Not run.
- Verified the diff for updated component props and icon imports across affected pages.
- Confirmed dependency updates were reflected in both `package.json` and `bun.lock`.