### PR TITLE
feat(seo): robots.txt, sitemap, homepage-only indexing

### DIFF
--- a/src/app/debug/layout.tsx
+++ b/src/app/debug/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function DebugLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 import "./globals.css";
 import { SettingsProvider } from "@/lib/settings-context";
+import { getSiteUrl } from "@/lib/site-url";
 
 const poppins = Poppins({
   variable: "--font-poppins",
@@ -10,6 +11,7 @@ const poppins = Poppins({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getSiteUrl()),
   title: { default: "wattlyzer", template: "%s | wattlyzer" },
   description: "Smart energy scheduling tool that optimizes when to run your appliances based on solar production and electricity prices.",
   manifest: "/site.webmanifest",

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -7,6 +7,7 @@ import { FooterLinks } from "@/components/footer-links";
 export const metadata: Metadata = {
   title: "Legal Notice",
   description: "Legal notice and contact information for wattlyzer",
+  robots: { index: false, follow: false },
 };
 
 function InfoCard({

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -13,6 +13,7 @@ import { FooterLinks } from "@/components/footer-links";
 export const metadata: Metadata = {
   title: "Privacy Policy",
   description: "Privacy policy for wattlyzer - how we handle your data",
+  robots: { index: false, follow: false },
 };
 
 function PrivacyCard({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { getSiteUrl } from "@/lib/site-url";
+
+/** Block crawling of app sub-routes; `/` and static assets (e.g. `/_next/`) stay allowed. */
+const DISALLOW_SUBROUTES = ["/settings", "/privacy", "/legal", "/debug"] as const;
+
+export default function robots(): MetadataRoute.Robots {
+  const base = getSiteUrl();
+  return {
+    rules: {
+      userAgent: "*",
+      disallow: [...DISALLOW_SUBROUTES],
+    },
+    sitemap: `${base}/sitemap.xml`,
+  };
+}

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+import { getSiteUrl } from "@/lib/site-url";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = getSiteUrl();
+  return [
+    {
+      url: `${base}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Public site origin (no trailing slash) for absolute URLs: `metadataBase`,
+ * `robots.ts` / `sitemap.ts`, and any future metadata. Prefer
+ * `NEXT_PUBLIC_SITE_URL` in production so the canonical host is not `*.vercel.app`.
+ */
+export function getSiteUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (explicit) {
+    return explicit.replace(/\/$/, "");
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return "http://localhost:3000";
+}


### PR DESCRIPTION
Adds Next.js metadata routes for `/robots.txt` and `/sitemap.xml`, canonical site URL helper, `metadataBase`, disallow crawling of app sub-routes while listing only the home URL in the sitemap, and `noindex` on non-home routes.