### PR TITLE
feat(weather): rain, snow, and fog sky visuals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ TanStack Start's SSR function only renders a shell that immediately hydrates; al
 - `solar-only`: ignore prices; pick the sunniest qualifying slot.
 - `price-only`: ignore solar; pick the cheapest slot.
 
-`calculatePowerGeneration` interpolates cumulative-Wh samples from forecast.solar, applies the fixed `0.7` production factor, then halves output inside morning/evening shading windows. `src/lib/weather.ts` maps real cloud cover to a `WeatherKind`, falling back to a solar-peak heuristic (`forecastWeather`) when weather data is missing.
+`calculatePowerGeneration` interpolates cumulative-Wh samples from forecast.solar, applies the fixed `0.7` production factor, then halves output inside morning/evening shading windows. `src/lib/weather.ts` maps real DWD data to a `WeatherKind`: a precipitation/fog `condition` (or measured precipitation) wins as `rainy`/`snowy`/`foggy` over the cloud-cover band (`sunny`/`partly`/`cloudy`/`overcast`), falling back to a solar-peak heuristic (`forecastWeather`) when weather data is missing. The hero (`src/components/sky/clouds.tsx`) renders darker clouds for those kinds, with CSS-animated rain streaks / snow flakes overlaid.
 
 **UI — the "Sky" design system (`src/components/sky/`).** Inline styles only, no CSS framework (intentional — do not introduce one). `skyTheme(hour)` (`src/lib/sky-theme.ts`) returns the full palette for a local hour; the home gradient, sun/moon arc, and text colors all derive from it. Fraunces is the display font.
 

--- a/src/components/sky/clouds.tsx
+++ b/src/components/sky/clouds.tsx
@@ -1,5 +1,6 @@
 import { useId } from "react";
 import type { SkyTheme } from "@/lib/sky-theme";
+import type { WeatherKind } from "@/lib/weather";
 
 // Smooth vector cloud — one continuous silhouette path (no stacked blobs),
 // vertical gradient for volume and a soft blurred highlight on top.
@@ -124,22 +125,101 @@ export function SkySunCloud({
   );
 }
 
-export function SkyClouds({ heavy, t }: { heavy: boolean; t: SkyTheme }) {
-  // Layered clouds at varied scales — heavier overcast = more clouds, dimmer
-  const tint = heavy
+// Vertical rain streaks under the cloud band. Left/top come from the index
+// (never Math.random) so SSR and hydration agree, and the fall is pure CSS so
+// the React Compiler can still memoize the component.
+function SkyRain({ t }: { t: SkyTheme }) {
+  const color =
+    t.mode === "dark" ? "rgba(206,220,245,0.55)" : "rgba(96,128,184,0.5)";
+  return (
+    <>
+      {Array.from({ length: 18 }, (_, i) => {
+        const left = 6 + (i * 88) / 17; // spread 6% → 94%
+        const top = 15 + ((i * 7) % 10); // scattered 15% → 24%
+        const dur = 0.85 + (i % 4) * 0.12;
+        const delay = -((i * 0.17) % 1.2); // negative → start mid-fall
+        return (
+          <div
+            key={i}
+            style={{
+              position: "absolute",
+              left: `${left}%`,
+              top: `${top}%`,
+              width: 2,
+              height: 16,
+              borderRadius: 2,
+              background: `linear-gradient(to bottom, transparent, ${color} 35%, ${color} 65%, transparent)`,
+              transform: "rotate(8deg)",
+              animation: `sky-rain-fall ${dur}s linear ${delay}s infinite`,
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+// Drifting snow flakes — slower than rain, with a gentle sideways sway baked
+// into the keyframes. Same index-derived, CSS-only approach as SkyRain.
+function SkySnow({ t }: { t: SkyTheme }) {
+  const color =
+    t.mode === "dark" ? "rgba(255,255,255,0.92)" : "rgba(255,255,255,0.95)";
+  return (
+    <>
+      {Array.from({ length: 16 }, (_, i) => {
+        const left = 6 + (i * 88) / 15;
+        const top = 14 + ((i * 5) % 11);
+        const size = 5 + (i % 3);
+        const dur = 3.2 + (i % 5) * 0.5;
+        const delay = -((i * 0.4) % 3);
+        return (
+          <div
+            key={i}
+            style={{
+              position: "absolute",
+              left: `${left}%`,
+              top: `${top}%`,
+              width: size,
+              height: size,
+              borderRadius: "50%",
+              background: color,
+              boxShadow: `0 0 6px ${color}`,
+              animation: `sky-snow-fall ${dur}s linear ${delay}s infinite`,
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export function SkyClouds({ kind, t }: { kind: WeatherKind; t: SkyTheme }) {
+  // rainy/snowy/foggy share a darker, moodier cloud base; overcast keeps the
+  // lighter "heavy" grey; cloudy uses the bright white clouds.
+  const dark = kind === "rainy" || kind === "snowy" || kind === "foggy";
+  const heavy = dark || kind === "overcast";
+  const tint = dark
     ? t.mode === "dark"
-      ? "rgba(210,212,225,0.85)"
-      : "#eceef3"
-    : t.mode === "dark"
-      ? "rgba(240,238,250,0.94)"
-      : "#ffffff";
-  const shade = heavy
+      ? "rgba(176,180,198,0.92)"
+      : "#c7ccd8"
+    : heavy
+      ? t.mode === "dark"
+        ? "rgba(210,212,225,0.85)"
+        : "#eceef3"
+      : t.mode === "dark"
+        ? "rgba(240,238,250,0.94)"
+        : "#ffffff";
+  const shade = dark
     ? t.mode === "dark"
-      ? "rgba(150,152,170,0.7)"
-      : "rgba(176,180,196,0.9)"
-    : t.mode === "dark"
-      ? "rgba(195,195,215,0.6)"
-      : "rgba(214,210,222,0.85)";
+      ? "rgba(120,124,144,0.85)"
+      : "rgba(128,134,152,0.95)"
+    : heavy
+      ? t.mode === "dark"
+        ? "rgba(150,152,170,0.7)"
+        : "rgba(176,180,196,0.9)"
+      : t.mode === "dark"
+        ? "rgba(195,195,215,0.6)"
+        : "rgba(214,210,222,0.85)";
   return (
     <>
       <Cloud left="4%" top="9%" scale={1.2} drift={1} opacity={heavy ? 0.96 : 0.94} tint={tint} shade={shade} />
@@ -148,6 +228,8 @@ export function SkyClouds({ heavy, t }: { heavy: boolean; t: SkyTheme }) {
       {heavy && (
         <Cloud left="64%" top="19%" scale={1.05} drift={4} flip opacity={0.9} tint={tint} shade={shade} />
       )}
+      {kind === "rainy" && <SkyRain t={t} />}
+      {kind === "snowy" && <SkySnow t={t} />}
     </>
   );
 }

--- a/src/components/sky/home.tsx
+++ b/src/components/sky/home.tsx
@@ -93,9 +93,12 @@ export function SkyHero({
           sunSize={sunSize}
         />
       )}
-      {showSun && (weather === "cloudy" || weather === "overcast") && (
-        <SkyClouds heavy={weather === "overcast"} t={t} />
-      )}
+      {showSun &&
+        (weather === "cloudy" ||
+          weather === "overcast" ||
+          weather === "rainy" ||
+          weather === "snowy" ||
+          weather === "foggy") && <SkyClouds kind={weather} t={t} />}
       {!showSun && (
         <div
           style={{

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,11 +23,16 @@ export type SolarData = {
   };
 };
 
-// BrightSky (api.brightsky.dev) hourly DWD weather — only the fields we read
+// BrightSky (api.brightsky.dev) hourly DWD weather — only the fields we read.
+// `condition` is DWD's categorical sky state (dry/fog/rain/sleet/snow/hail/
+// thunderstorm) and `precipitation` is the hour's rainfall in mm; both drive
+// the rain/snow/fog hero visuals.
 export type WeatherData = {
   weather: Array<{
     timestamp: string;
     cloud_cover: number | null;
+    condition?: string | null;
+    precipitation?: number | null;
   }>;
 };
 

--- a/src/lib/weather.test.ts
+++ b/src/lib/weather.test.ts
@@ -4,6 +4,7 @@ import type { SolarData, WeatherData } from "@/lib/types";
 import {
   cloudCoverAt,
   cloudCoverToKind,
+  conditionToKind,
   forecastWeather,
   weatherAt,
 } from "@/lib/weather";
@@ -154,6 +155,19 @@ function brightSky(records: Array<[string, number | null]>): WeatherData {
   };
 }
 
+// Full BrightSky records including the condition + precipitation fields used
+// by the rain/snow/fog classification.
+function brightSkyFull(
+  records: Array<{
+    timestamp: string;
+    cloud_cover: number | null;
+    condition: string | null;
+    precipitation: number | null;
+  }>,
+): WeatherData {
+  return { weather: records };
+}
+
 describe("cloudCoverToKind", () => {
   it("maps cloud-cover bands at the 25 / 50 / 85 boundaries", () => {
     expect(cloudCoverToKind(0)).toBe("sunny");
@@ -164,6 +178,33 @@ describe("cloudCoverToKind", () => {
     expect(cloudCoverToKind(85)).toBe("cloudy");
     expect(cloudCoverToKind(86)).toBe("overcast");
     expect(cloudCoverToKind(100)).toBe("overcast");
+  });
+});
+
+describe("conditionToKind", () => {
+  it("maps wet, falling precipitation to rainy", () => {
+    expect(conditionToKind("rain", 0)).toBe("rainy");
+    expect(conditionToKind("sleet", 0)).toBe("rainy");
+    expect(conditionToKind("hail", 0)).toBe("rainy");
+    expect(conditionToKind("thunderstorm", 0)).toBe("rainy");
+  });
+
+  it("maps snow to snowy and fog to foggy", () => {
+    expect(conditionToKind("snow", 0)).toBe("snowy");
+    expect(conditionToKind("fog", 0)).toBe("foggy");
+  });
+
+  it("returns null for dry / unknown / absent labels so cloud cover decides", () => {
+    expect(conditionToKind("dry", 0)).toBe(null);
+    expect(conditionToKind("future-dwd-code", 0)).toBe(null);
+    expect(conditionToKind(null, 0)).toBe(null);
+    expect(conditionToKind(undefined, undefined)).toBe(null);
+  });
+
+  it("treats measured precipitation as rain when the label is missing", () => {
+    expect(conditionToKind(null, 0.4)).toBe("rainy");
+    expect(conditionToKind(undefined, 2)).toBe("rainy");
+    expect(conditionToKind(null, 0)).toBe(null);
   });
 });
 
@@ -220,5 +261,69 @@ describe("weatherAt", () => {
     expect(weatherAt(nullCover, dayWithPeak(200), baseSettings, noon)).toBe(
       "overcast",
     );
+  });
+
+  it("lets the precipitation condition win over the cloud-cover band", () => {
+    // clear-ish sky (40%) but it's raining — rain must take precedence
+    const data = brightSkyFull([
+      {
+        timestamp: "2025-01-15T12:00:00+00:00",
+        cloud_cover: 40,
+        condition: "rain",
+        precipitation: 1.2,
+      },
+    ]);
+    expect(weatherAt(data, dayWithPeak(2800), baseSettings, noon)).toBe("rainy");
+  });
+
+  it("classifies snow and fog from the condition", () => {
+    const snowy = brightSkyFull([
+      {
+        timestamp: "2025-01-15T12:00:00+00:00",
+        cloud_cover: 90,
+        condition: "snow",
+        precipitation: 0.5,
+      },
+    ]);
+    const foggy = brightSkyFull([
+      {
+        timestamp: "2025-01-15T12:00:00+00:00",
+        cloud_cover: 90,
+        condition: "fog",
+        precipitation: 0,
+      },
+    ]);
+    expect(weatherAt(snowy, dayWithPeak(2800), baseSettings, noon)).toBe(
+      "snowy",
+    );
+    expect(weatherAt(foggy, dayWithPeak(2800), baseSettings, noon)).toBe(
+      "foggy",
+    );
+  });
+
+  it("falls back to the cloud-cover band when the condition is dry", () => {
+    const data = brightSkyFull([
+      {
+        timestamp: "2025-01-15T12:00:00+00:00",
+        cloud_cover: 90,
+        condition: "dry",
+        precipitation: 0,
+      },
+    ]);
+    expect(weatherAt(data, dayWithPeak(2800), baseSettings, noon)).toBe(
+      "overcast",
+    );
+  });
+
+  it("uses measured precipitation when the condition label is missing", () => {
+    const data = brightSkyFull([
+      {
+        timestamp: "2025-01-15T12:00:00+00:00",
+        cloud_cover: 10,
+        condition: null,
+        precipitation: 0.3,
+      },
+    ]);
+    expect(weatherAt(data, dayWithPeak(2800), baseSettings, noon)).toBe("rainy");
   });
 });

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -2,7 +2,16 @@ import { calculatePowerGeneration } from "@/lib/schedule";
 import type { SettingsData } from "@/lib/settings";
 import type { SolarData, WeatherData } from "@/lib/types";
 
-export type WeatherKind = "sunny" | "partly" | "cloudy" | "overcast";
+export type WeatherKind =
+  | "sunny"
+  | "partly"
+  | "cloudy"
+  | "overcast"
+  | "rainy"
+  | "snowy"
+  | "foggy";
+
+type WeatherRecord = WeatherData["weather"][number];
 
 // Cloud-cover (%) bands for the sky hero
 export function cloudCoverToKind(cover: number): WeatherKind {
@@ -12,24 +21,60 @@ export function cloudCoverToKind(cover: number): WeatherKind {
   return "overcast";
 }
 
-// Cloud cover of the hourly record covering `at`, or null when missing
-export function cloudCoverAt(
+/**
+ * Precipitation/fog kind from a DWD `condition` label, or null when the sky
+ * state should instead be decided by cloud cover. Wet falling precipitation
+ * (rain/sleet/hail/thunderstorm) reads as `rainy`; snow as `snowy`; fog as
+ * `foggy`. When DWD omits the label, a positive measured precipitation falls
+ * back to `rainy` so a passing shower still shows.
+ */
+export function conditionToKind(
+  condition: string | null | undefined,
+  precipitation: number | null | undefined,
+): WeatherKind | null {
+  switch (condition) {
+    case "rain":
+    case "sleet":
+    case "hail":
+    case "thunderstorm":
+      return "rainy";
+    case "snow":
+      return "snowy";
+    case "fog":
+      return "foggy";
+  }
+  if (precipitation != null && precipitation > 0) return "rainy";
+  return null;
+}
+
+// The hourly record covering `at`, or null when missing
+function weatherRecordAt(
   data: WeatherData | null,
   at: Date,
-): number | null {
+): WeatherRecord | null {
   if (!data?.weather) return null;
   const hourStart = Math.floor(at.getTime() / 3_600_000) * 3_600_000;
   for (const record of data.weather) {
     if (Date.parse(record.timestamp) === hourStart) {
-      return record.cloud_cover;
+      return record;
     }
   }
   return null;
 }
 
+// Cloud cover of the hourly record covering `at`, or null when missing
+export function cloudCoverAt(
+  data: WeatherData | null,
+  at: Date,
+): number | null {
+  return weatherRecordAt(data, at)?.cloud_cover ?? null;
+}
+
 /**
- * Sky at the given moment: real DWD cloud cover when available, otherwise
- * the solar-forecast heuristic.
+ * Sky at the given moment. Real DWD data wins when available: a precipitation
+ * or fog condition takes precedence over cloud cover (it can rain under a
+ * not-fully-overcast sky), otherwise the cloud-cover band decides. With no
+ * record, the solar-forecast heuristic fills in.
  */
 export function weatherAt(
   weatherData: WeatherData | null,
@@ -37,9 +82,13 @@ export function weatherAt(
   settings: SettingsData,
   at: Date,
 ): WeatherKind {
-  const cover = cloudCoverAt(weatherData, at);
-  if (cover !== null) {
-    return cloudCoverToKind(cover);
+  const record = weatherRecordAt(weatherData, at);
+  if (record) {
+    const precip = conditionToKind(record.condition, record.precipitation);
+    if (precip) return precip;
+    if (record.cloud_cover !== null) {
+      return cloudCoverToKind(record.cloud_cover);
+    }
   }
   return forecastWeather(solarData, settings, at);
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -46,6 +46,34 @@ a {
   }
 }
 
+@keyframes sky-rain-fall {
+  0% {
+    transform: translateY(-14px) rotate(8deg);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(64px) rotate(8deg);
+    opacity: 0;
+  }
+}
+
+@keyframes sky-snow-fall {
+  0% {
+    transform: translate(0, -14px);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(10px, 72px);
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   * {
     animation-duration: 0.01ms !important;


### PR DESCRIPTION
## What

Since the app already pulls DWD weather from BrightSky, the sky hero now distinguishes **rain**, **snow**, and **fog** instead of only cloud cover.

| Condition | WeatherKind | Visual |
|---|---|---|
| `rain`, `thunderstorm`, `sleet`, `hail` | `rainy` | darker clouds + animated rain streaks |
| `snow` | `snowy` | darker clouds + animated snow flakes |
| `fog` | `foggy` | darker clouds, no falling precipitation |
| `dry` / missing | _(unchanged)_ | cloud-cover band → `sunny`/`partly`/`cloudy`/`overcast` |

## How

- **`src/lib/types.ts`** — read `condition` + `precipitation` from the BrightSky record (previously only `cloud_cover`).
- **`src/lib/weather.ts`** — extend `WeatherKind`; new pure `conditionToKind(condition, precipitation)`. `weatherAt` checks the condition **first** (it can rain under a not-fully-overcast sky), then the cloud-cover band, then the existing solar-peak fallback. Missing label but `precipitation > 0` falls back to `rainy`.
- **`src/components/sky/clouds.tsx`** — darker cloud base for the new kinds; new `SkyRain` / `SkySnow` overlays with **index-derived positions** (no `Math.random`) and **CSS-only** animation, keeping them React-Compiler- and hydration-safe.
- **`src/styles/app.css`** — `@keyframes sky-rain-fall` / `sky-snow-fall` (covered by the existing `prefers-reduced-motion` guard).
- **`AGENTS.md`** — documented the new condition→kind mapping.

## Scope decisions
- Sleet & hail grouped with rain (wet, falling).
- Precipitation visuals are **daytime-only** (hour 6–20), matching the current cloud behavior; at night the hero still shows just the moon.

## Testing
- TDD: 12 new tests in `weather.test.ts` covering the mapping, condition-over-cloud-cover precedence, the precipitation fallback, and `dry`/missing falling through. Full suite **95 pass / 0 fail**.
- `bunx tsc --noEmit` clean; `bun run build` succeeds (React Compiler accepts the new components).
- Rendered a faithful static preview of the rainy/snowy states to confirm the visuals.