### PR TITLE
fix(ui): wrap row text so labels are never occluded by trailing controls on mobile

### DIFF
--- a/src/components/sky/rows.tsx
+++ b/src/components/sky/rows.tsx
@@ -64,9 +64,9 @@ export function ObSwitchRow({
               color: t.fgDim,
               fontFamily: FONT_MONO,
               letterSpacing: "0.02em",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
+              // Wrap long text instead of truncating so nothing is occluded
+              // by the trailing control (matches SetToggleRow in settings).
+              overflowWrap: "anywhere",
             }}
           >
             {subtitle}
@@ -213,9 +213,9 @@ export function ObCard({
             color: t.fgDim,
             fontFamily: FONT_MONO,
             letterSpacing: "0.02em",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
+            // Wrap long text instead of truncating so nothing is occluded
+            // by the trailing control (matches SetToggleRow in settings).
+            overflowWrap: "anywhere",
           }}
         >
           {status}

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -162,7 +162,9 @@ function SetToggleRow({
             color: t.fgMute,
             fontFamily: FONT_MONO,
             marginTop: 2,
-            whiteSpace: "nowrap",
+            // Let long descriptions (e.g. the Dark mode hint) wrap instead of
+            // overflowing the minWidth:0 column and running under the switch.
+            overflowWrap: "anywhere",
           }}
         >
           {detail}


### PR DESCRIPTION
## Problem

On narrow/mobile screens, descriptive text in list rows could be hidden by the control sitting to its right:

- **Settings → Appearance → Dark mode**: the description ("Match the sky to now, not the chosen slot") ran *under* the toggle and was clipped — the word "slot" was occluded.
- **Onboarding rows** (`ObSwitchRow` / `ObCard`) truncated long subtitle/status text with an ellipsis, e.g. the dynamic-tariff hint lost "(e.g. Tibber, aWATTar)".

## Root cause

All of these rows put `whiteSpace: "nowrap"` text in a `minWidth: 0` flex column next to a fixed-width control:
- `SetToggleRow` (settings) had no overflow handling, so the text overflowed and ran under the switch (clipped by the group's `overflow: hidden`).
- `ObSwitchRow` / `ObCard` (rows) used `overflow: hidden` + `textOverflow: "ellipsis"`, which avoided the overlap but *hid* part of the text behind "…".

## Fix

Let the text **wrap** (`overflowWrap: "anywhere"`) in all three components. The columns are already `minWidth: 0` (enables shrink-to-wrap) and every trailing control is `flexShrink: 0` (keeps its size). Result: full text is always visible, nothing occluded, consistent across the app.

I also swept every `whiteSpace: "nowrap"` in the codebase — the remaining ones are short fixed strings ("Run for", "3h", segmented-control labels, settings values) or the self-scaling hero countdown, none of which can clip.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run test:run` — 99 pass, 0 fail
- Browser (Playwright) at **390px** and **320px**: settings Dark mode row and onboarding rows all wrap and stay fully visible; bounding-box checks confirm **no overlap** with the trailing switch/button (12–14px gap retained at 320px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)